### PR TITLE
Update routers when config changes

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -18,6 +18,17 @@ func labelsForQdr(name string) map[string]string {
 	}
 }
 
+func CheckDeployedContainer(actual *corev1.PodTemplateSpec, cr *v1alpha1.Qdr) bool {
+	desired := containers.ContainerForQdr(cr)
+	if len(actual.Spec.Containers) != 1 || !containers.CheckQdrContainer(&desired, &actual.Spec.Containers[0]) {
+		actual.Spec.Containers = []corev1.Container{desired}
+		return false
+	}
+	return true
+}
+
+
+
 // Create NewDeploymentForCR method to create deployment
 func NewDeploymentForCR(m *v1alpha1.Qdr) *appsv1.Deployment {
 	labels := selectors.LabelsForQdr(m.Name)
@@ -70,16 +81,6 @@ func NewDeploymentForCR(m *v1alpha1.Qdr) *appsv1.Deployment {
 		},
 	}
 	volumes := []corev1.Volume{}
-	volumes = append(volumes, corev1.Volume{
-		Name: m.Name,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: m.Name,
-				},
-			},
-		},
-	})
 	for _, profile := range m.Spec.SslProfiles {
 		if len(profile.Credentials) > 0 {
 			volumes = append(volumes, corev1.Volume{
@@ -136,16 +137,6 @@ func NewDaemonSetForCR(m *v1alpha1.Qdr) *appsv1.DaemonSet {
 		},
 	}
 	volumes := []corev1.Volume{}
-	volumes = append(volumes, corev1.Volume{
-		Name: m.Name,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: m.Name,
-				},
-			},
-		},
-	})
 	for _, profile := range m.Spec.SslProfiles {
 		if len(profile.Credentials) > 0 {
 			volumes = append(volumes, corev1.Volume{


### PR DESCRIPTION
This passes the config as an env var rather than a configmap. That allows changes to automatically new rollout router pods. As we don't want people to edit the configmap anyway, this seems justified to me. At present it checks the image and the router config for changes, and updates the deployment if necessary. The config check should pick up changes in listeners for ports etc and even ssl profile differences. (Checking for changes in placement option and other aspects not reflected in the router config is left for a future PR).  