### PR TITLE
conditionalize default tls listener

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -769,7 +769,9 @@
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = "NT"
   revision = "0cd23ebeb6882bd1cdc2cb15fc7b2d72e8a86a5b"
@@ -1030,6 +1032,8 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: qdr-operator
+rules:
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: qdr-operator
+subjects:
+- kind: ServiceAccount
+  namespace: default
+  name: qdr-operator
+roleRef:
+  kind: ClusterRole
+  name: qdr-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/resources/certificates/certificate.go
+++ b/pkg/resources/certificates/certificate.go
@@ -3,8 +3,56 @@ package certificates
 import (
 	v1alpha1 "github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
 	cmv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var (
+	certmgr_detected *bool
+	log              = logf.Log.WithName("certificates")
+)
+
+func DetectCertmgrIssuer() bool {
+	// find certmanager issuer crd
+	if certmgr_detected == nil {
+		iscm := detectCertmgr()
+		certmgr_detected = &iscm
+	}
+	return *certmgr_detected
+}
+
+func detectCertmgr() bool {
+	config, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "Error getting config: %v")
+		return false
+	}
+
+	// create a client set that includes crd schema
+	extClient, err := apiextclientset.NewForConfig(config)
+	if err != nil {
+		log.Error(err, "Error getting ext client set: %v")
+		return false
+	}
+
+	crdList := &apiextv1b1.CustomResourceDefinitionList{}
+	crdList, err = extClient.ApiextensionsV1beta1().CustomResourceDefinitions().List(metav1.ListOptions{})
+	if err != nil {
+		log.Error(err, "Error getting CustomResoruceDefinition list: %v")
+		return false
+	}
+
+	for _, crd := range crdList.Items {
+		if crd.Name == "issuers.certmanager.k8s.io" {
+			log.Info("Certmanager issuer detected")
+			return true
+		}
+	}
+	return false
+}
 
 func NewSelfSignedIssuerForCR(m *v1alpha1.Qdr) *cmv1alpha1.Issuer {
 	issuer := &cmv1alpha1.Issuer{

--- a/pkg/resources/certificates/certificate.go
+++ b/pkg/resources/certificates/certificate.go
@@ -38,19 +38,16 @@ func detectCertmgr() bool {
 		return false
 	}
 
-	crdList := &apiextv1b1.CustomResourceDefinitionList{}
-	crdList, err = extClient.ApiextensionsV1beta1().CustomResourceDefinitions().List(metav1.ListOptions{})
+	crd := &apiextv1b1.CustomResourceDefinition{}
+	crd, err = extClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("issuers.certmanager.k8s.io", metav1.GetOptions{})
 	if err != nil {
-		log.Error(err, "Error getting CustomResoruceDefinition list: %v")
+		log.Error(err, "Error getting certmanager issuer crd: %v")
 		return false
+	} else {
+		log.Info("Detected certmanager issuer crd", "issuer", crd)
+		return true
 	}
 
-	for _, crd := range crdList.Items {
-		if crd.Name == "issuers.certmanager.k8s.io" {
-			log.Info("Certmanager issuer detected")
-			return true
-		}
-	}
 	return false
 }
 

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -6,6 +6,7 @@ import (
 
 	v1alpha1 "github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
 	"github.com/interconnectedcloud/qdr-operator/pkg/constants"
+	"github.com/interconnectedcloud/qdr-operator/pkg/resources/certificates"
 )
 
 func isDefaultSslProfileDefined(m *v1alpha1.Qdr) bool {
@@ -55,6 +56,7 @@ func GetQdrExposedListeners(m *v1alpha1.Qdr) []v1alpha1.Listener {
 func SetQdrDefaults(m *v1alpha1.Qdr) (bool, bool) {
 	requestCert := false
 	updateDefaults := false
+	certMgrPresent := certificates.DetectCertmgrIssuer()
 
 	if m.Spec.DeploymentPlan.Size == 0 {
 		m.Spec.DeploymentPlan.Size = 1
@@ -73,18 +75,29 @@ func SetQdrDefaults(m *v1alpha1.Qdr) (bool, bool) {
 		m.Spec.Listeners = append(m.Spec.Listeners, v1alpha1.Listener{
 			Port: 5672,
 		}, v1alpha1.Listener{
-			Port: 5671,
-		}, v1alpha1.Listener{
 			Port: constants.HttpLivenessPort,
 			Http: true,
 		})
+		if certMgrPresent {
+			m.Spec.Listeners = append(m.Spec.Listeners, v1alpha1.Listener{
+				Port:       5671,
+				SslProfile: "default",
+			})
+		}
 		updateDefaults = true
 	}
 	if m.Spec.DeploymentPlan.Role == v1alpha1.RouterRoleInterior {
 		if len(m.Spec.InterRouterListeners) == 0 {
-			m.Spec.InterRouterListeners = append(m.Spec.InterRouterListeners, v1alpha1.Listener{
-				Port: 55672,
-			})
+			if certMgrPresent {
+				m.Spec.InterRouterListeners = append(m.Spec.InterRouterListeners, v1alpha1.Listener{
+					Port:       55671,
+					SslProfile: "default",
+				})
+			} else {
+				m.Spec.InterRouterListeners = append(m.Spec.InterRouterListeners, v1alpha1.Listener{
+					Port: 55672,
+				})
+			}
 			updateDefaults = true
 		}
 		if len(m.Spec.EdgeListeners) == 0 {

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -121,7 +121,7 @@ func SetQdrDefaults(m *v1alpha1.Qdr) (bool, bool) {
 			requestCert = true
 		}
 	}
-	return requestCert, updateDefaults
+	return requestCert && certMgrPresent, updateDefaults
 }
 
 func ConfigForQdr(m *v1alpha1.Qdr) string {


### PR DESCRIPTION
This patch checks for the certmanager issuer crd present to conditionalize the default tls related listeners.
The addition of a cluster role was needed to be able to query the crd list.