### PR TITLE
Add liveness port to deployment plan

### DIFF
--- a/deploy/crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml
+++ b/deploy/crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml
@@ -66,6 +66,9 @@ spec:
                 issuer:
                   type: string
                   description: The externally provided credentials
+                livenessPort:
+                  type: integer
+                  description: The liveness probe port number
             listeners:
               type: array
               description: Configuration of each individual interconnect listener

--- a/deploy/olm-catalog/qdr-operator/0.1.0/catalog-source.yaml
+++ b/deploy/olm-catalog/qdr-operator/0.1.0/catalog-source.yaml
@@ -335,6 +335,9 @@ items:
                           issuer:
                             type: string
                             description: The externally provided credentials
+                          livenessPort:
+                            type: integer
+                            description: The liveness probe port number
                       listeners:
                         type: array
                         description: Configuration of each individual interconnect listener

--- a/pkg/apis/interconnectedcloud/v1alpha1/interconnect_types.go
+++ b/pkg/apis/interconnectedcloud/v1alpha1/interconnect_types.go
@@ -98,12 +98,13 @@ const (
 )
 
 type DeploymentPlanType struct {
-	Image     string                      `json:"image,omitempty"`
-	Size      int32                       `json:"size,omitempty"`
-	Role      RouterRoleType              `json:"role,omitempty"`
-	Placement PlacementType               `json:"placement,omitempty"`
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	Issuer    string                      `json:"issuer,omitempty"`
+	Image        string                      `json:"image,omitempty"`
+	Size         int32                       `json:"size,omitempty"`
+	Role         RouterRoleType              `json:"role,omitempty"`
+	Placement    PlacementType               `json:"placement,omitempty"`
+	Resources    corev1.ResourceRequirements `json:"resources,omitempty"`
+	Issuer       string                      `json:"issuer,omitempty"`
+	LivenessPort int32                       `json:"livenessPort,omitempty"`
 }
 
 type Address struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,5 +2,5 @@ package constants
 
 const (
 	CertRequestAnnotation = "service.alpha.interconnectedcloud.io/serving-cert-secret-name"
-	HttpLivenessPort      = 8672
+	HttpLivenessPort      = 8080
 )

--- a/pkg/resources/containers/container.go
+++ b/pkg/resources/containers/container.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	v1alpha1 "github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
-	"github.com/interconnectedcloud/qdr-operator/pkg/constants"
 	"github.com/interconnectedcloud/qdr-operator/pkg/utils/configs"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -103,7 +102,7 @@ func ContainerForInterconnect(m *v1alpha1.Interconnect) corev1.Container {
 			InitialDelaySeconds: 60,
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Port: intstr.FromInt(constants.HttpLivenessPort),
+					Port: intstr.FromInt(int(m.Spec.DeploymentPlan.LivenessPort)),
 				},
 			},
 		},

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -70,12 +70,16 @@ func SetInterconnectDefaults(m *v1alpha1.Interconnect) (bool, bool) {
 		m.Spec.DeploymentPlan.Placement = v1alpha1.PlacementAny
 		updateDefaults = true
 	}
+	if m.Spec.DeploymentPlan.LivenessPort == 0 {
+		m.Spec.DeploymentPlan.LivenessPort = constants.HttpLivenessPort
+		updateDefaults = true
+	}
 
 	if len(m.Spec.Listeners) == 0 {
 		m.Spec.Listeners = append(m.Spec.Listeners, v1alpha1.Listener{
 			Port: 5672,
 		}, v1alpha1.Listener{
-			Port: constants.HttpLivenessPort,
+			Port: m.Spec.DeploymentPlan.LivenessPort,
 			Http: true,
 		})
 		if certMgrPresent {


### PR DESCRIPTION
This patch adds a livenessPort to the deployment plan to enable changing the port used for liveness checks of the interconnect pod instances. If a livenessPort is not provided in the plan, a default constant port is used (8080).