### PR TITLE
rename requireClientCerts to mutualAuth 

### DIFF
--- a/deploy/crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml
+++ b/deploy/crds/interconnectedcloud_v1alpha1_interconnect_crd.yaml
@@ -334,7 +334,7 @@ spec:
                     type: string
                   protocols:
                     type: string
-                  requireClientCerts:
+                  mutualAuth:
                     type: boolean
                 type: object
               type: array

--- a/deploy/olm-catalog/qdr-operator/0.1.0/catalog-source.yaml
+++ b/deploy/olm-catalog/qdr-operator/0.1.0/catalog-source.yaml
@@ -603,7 +603,7 @@ items:
                               type: string
                             protocols:
                               type: string
-                            requireClientCerts:
+                            mutualAuth:
                               type: boolean
                           type: object
                         type: array

--- a/pkg/apis/interconnectedcloud/v1alpha1/interconnect_types.go
+++ b/pkg/apis/interconnectedcloud/v1alpha1/interconnect_types.go
@@ -131,12 +131,12 @@ type Listener struct {
 }
 
 type SslProfile struct {
-	Name               string `json:"name,omitempty"`
-	Credentials        string `json:"credentials,omitempty"`
-	CaCert             string `json:"caCert,omitempty"`
-	RequireClientCerts bool   `json:"requireClientCerts,omitempty"`
-	Ciphers            string `json:"ciphers,omitempty"`
-	Protocols          string `json:"protocols,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Credentials string `json:"credentials,omitempty"`
+	CaCert      string `json:"caCert,omitempty"`
+	MutualAuth  bool   `json:"mutualAuth,omitempty"`
+	Ciphers     string `json:"ciphers,omitempty"`
+	Protocols   string `json:"protocols,omitempty"`
 }
 
 type LinkRoute struct {

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -119,9 +119,11 @@ func SetInterconnectDefaults(m *v1alpha1.Interconnect) (bool, bool) {
 		requestCert = true
 	}
 	for i := range m.Spec.SslProfiles {
-		if m.Spec.SslProfiles[i].Credentials == "" {
+		if m.Spec.SslProfiles[i].Credentials == "" && m.Spec.SslProfiles[i].CaCert == "" {
 			requestCert = true
-		} else if m.Spec.SslProfiles[i].RequireClientCerts && m.Spec.SslProfiles[i].CaCert == "" {
+		} else if m.Spec.SslProfiles[i].Credentials == "" && m.Spec.SslProfiles[i].MutualAuth {
+			requestCert = true
+		} else if m.Spec.SslProfiles[i].CaCert == "" && m.Spec.SslProfiles[i].MutualAuth {
 			requestCert = true
 		}
 	}


### PR DESCRIPTION
and update generation logic a little:

If mutualAuth is true, generate certs as necessary to ensure both credentials and cacert are defined. If it is false, only generate credentials if that is not provided.