### PR TITLE
secure and expose console by default

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,5 +2,5 @@ package constants
 
 const (
 	CertRequestAnnotation = "service.alpha.interconnectedcloud.io/serving-cert-secret-name"
-	HttpLivenessPort      = 8080
+	HttpLivenessPort      = 8888
 )

--- a/pkg/resources/containers/container.go
+++ b/pkg/resources/containers/container.go
@@ -109,6 +109,7 @@ func ContainerForInterconnect(m *v1alpha1.Interconnect) corev1.Container {
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Port: intstr.FromInt(int(m.Spec.DeploymentPlan.LivenessPort)),
+					Path: "/healthz",
 				},
 			},
 		},

--- a/pkg/utils/configs/config.go
+++ b/pkg/utils/configs/config.go
@@ -119,8 +119,10 @@ func SetInterconnectDefaults(m *v1alpha1.Interconnect, certMgrPresent bool) (boo
 		m.Spec.Listeners = append(m.Spec.Listeners, v1alpha1.Listener{
 			Port: 5672,
 		}, v1alpha1.Listener{
-			Port: m.Spec.DeploymentPlan.LivenessPort,
-			Http: true,
+			Port:             8080,
+			Http:             true,
+			Expose:           true,
+			AuthenticatePeer: true,
 		})
 		if certMgrPresent {
 			m.Spec.Listeners = append(m.Spec.Listeners, v1alpha1.Listener{
@@ -219,6 +221,15 @@ listener {
     {{- end}}
 }
 {{- end}}
+listener {
+    name: health-and-stats
+    port: {{.DeploymentPlan.LivenessPort}}
+    http: true
+    healthz: true
+    metrics: true
+    websockets: false
+    httpRootDir: invalid
+}
 {{range .InterRouterListeners}}
 listener {
     {{- if .Name}}


### PR DESCRIPTION
This relies on https://github.com/interconnectedcloud/qdr-operator/pull/36 on which it is based. The objective is that the console is accessible but secured by default. To do this the liveness probe and metrics scraping need to be separated into a distinct listener only configurable by port, but not providing any messaging access to the router network.

Note that this change will not work on qdrouterd images prior to the 1.5.0 release.