### PR TITLE
extra logging for apparent failure of deployment update

### DIFF
--- a/pkg/controller/interconnect/interconnect_controller.go
+++ b/pkg/controller/interconnect/interconnect_controller.go
@@ -483,7 +483,13 @@ func (r *ReconcileInterconnect) Reconcile(request reconcile.Request) (reconcile.
 		} else if !deployments.CheckDeployedContainer(&depFound.Spec.Template, instance) {
 			reqLogger.Info("Container config has changed")
 			ct := v1alpha1.InterconnectConditionProvisioning
-			r.client.Update(context.TODO(), depFound)
+			err = r.client.Update(context.TODO(), depFound)
+			if err != nil {
+				reqLogger.Error(err, "Failed to update Deployment", "error", err)
+				return reconcile.Result{}, err
+			} else {
+				reqLogger.Info("Deployment updated", "name", depFound.Name)
+			}
 			// update status
 			condition := v1alpha1.InterconnectCondition{
 				Type:           ct,


### PR DESCRIPTION
There is some bug whereby on occasion the controller appears to get stuck in a loop thinking the context has changed but never apparently being able to resolve it. I haven't been able to reproduce it at will, but adding some logging might help when it happens again.