### PR TITLE
Enhanced QdmanageQuery to use reflect and improve code reuse

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -2,11 +2,12 @@ package e2e
 
 import (
 	"context"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
 	"time"
 
 	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
 	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
-	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -91,7 +92,7 @@ func testInteriorDefaults(f *framework.Framework) {
 
 	By("Verifying each node has 5 addresses")
 	for _, pod := range pods {
-		addrs, err := qdrmanagement.QdmanageQueryAddresses(f, pod.Name)
+		addrs, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.Address{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(addrs)).To(Equal(5))
 	}
@@ -177,7 +178,7 @@ func testEdgeDefaults(f *framework.Framework) {
 
 	By("Verifying each node has 5 addresses")
 	for _, pod := range pods {
-		addrs, err := qdrmanagement.QdmanageQueryAddresses(f, pod.Name)
+		addrs, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.Address{}, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(addrs)).To(Equal(5))
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,7 +46,8 @@ const (
 
 var (
 	RetryInterval        = time.Second * 5
-	Timeout              = time.Second * 600
+	Timeout              = time.Second * 60
+	TimeoutSuite         = time.Second * 600
 	CleanupRetryInterval = time.Second * 1
 	CleanupTimeout       = time.Second * 5
 	GVR                  = groupName + "/" + apiVersion
@@ -220,7 +221,7 @@ func (f *Framework) Setup() error {
 		return fmt.Errorf("failed to setup qdr operator: %v", err)
 	}
 	err = f.setupQdrClusterRole()
-	if err != nil {
+	if err != nil && !HasAlreadyExistsSuffix(err) {
 		return fmt.Errorf("failed to setup qdr operator: %v", err)
 	}
 	err = f.setupQdrRoleBinding()
@@ -228,11 +229,11 @@ func (f *Framework) Setup() error {
 		return fmt.Errorf("failed to setup qdr operator: %v", err)
 	}
 	err = f.setupQdrClusterRoleBinding()
-	if err != nil {
+	if err != nil && !HasAlreadyExistsSuffix(err) {
 		return fmt.Errorf("failed to setup qdr operator: %v", err)
 	}
 	err = f.setupQdrCrd()
-	if err != nil {
+	if err != nil && !HasAlreadyExistsSuffix(err) {
 		return fmt.Errorf("failed to setup qdr operator: %v", err)
 	}
 	err = f.setupQdrDeployment()
@@ -244,6 +245,12 @@ func (f *Framework) Setup() error {
 		return fmt.Errorf("Failed to wait for qdr operator: %v", err)
 	}
 	return nil
+}
+
+// HasAlreadyExistsSuffix returns true if the string representation of the error
+// ends with "already exists".
+func HasAlreadyExistsSuffix(err error) bool {
+	return strings.HasSuffix(strings.ToLower(err.Error()), "already exists")
 }
 
 func (f *Framework) setupQdrServiceAccount() error {

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -2,10 +2,10 @@ package e2e
 
 import (
 	"context"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
 
 	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
 	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
-	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
* Previously we had to duplicate code to parse each possible
  Entity, but now the new version uses reflect api and helps
  keeping things under control
* Refactored impacted code
* Added 'already exists' error parsing when creating cluster
  level resources