### PR TITLE
Enhanced version matching to work with upstream and downstream versions

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -30,7 +30,7 @@ func testInteriorDefaults(f *framework.Framework) {
 	var (
 		name        = "interior-interconnect"
 		defaultSize = 1
-		version     = "1.9.0\n"
+		version     = "1.9.0"
 	)
 
 	By("Creating a default interior interconnect")
@@ -113,7 +113,7 @@ func testEdgeDefaults(f *framework.Framework) {
 		name        = "edge-interconnect"
 		role        = "edge"
 		defaultSize = 1
-		version     = "1.9.0\n"
+		version     = "1.9.0"
 	)
 
 	By("Creating an edge interconnect with default size")

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	RetryInterval        = time.Second * 5
-	Timeout              = time.Second * 60
+	Timeout              = time.Second * 120
 	TimeoutSuite         = time.Second * 600
 	CleanupRetryInterval = time.Second * 1
 	CleanupTimeout       = time.Second * 5

--- a/test/e2e/framework/qdrmanagement/networkstatus.go
+++ b/test/e2e/framework/qdrmanagement/networkstatus.go
@@ -92,7 +92,7 @@ func InterconnectHasExpectedInterRouterConnections(f *framework.Framework, inter
 // expected node counts, irc's, etc.
 func WaitUntilFullInterconnectWithQdrEntities(ctx context.Context, f *framework.Framework, interconnect *v1alpha1.Interconnect) error {
 
-	return framework.RetryWithContext(ctx, 10*time.Second, func() (bool, error) {
+	return framework.RetryWithContext(ctx, framework.RetryInterval, func() (bool, error) {
 		// Check that all the qdr pods have the expected node cound
 		n, err := InterconnectHasExpectedNodes(f, interconnect)
 		if err != nil {

--- a/test/e2e/framework/qdrmanagement/qdmanage.go
+++ b/test/e2e/framework/qdrmanagement/qdmanage.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	timeout time.Duration = 10 * time.Second
+	timeout time.Duration = 60 * time.Second
 )
 
 var (

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -26,7 +26,7 @@ var _ = Describe("[resize_test] Interconnect resize deployment tests", func() {
 func testInteriorResize(f *framework.Framework, initialSize int, finalSize int) {
 	var (
 		name    = "interior-interconnect"
-		version = "1.9.0\n"
+		version = "1.9.0"
 	)
 
 	By("Creating an interior interconnect with initial size")

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -26,8 +26,6 @@ func testInteriorImageUpgrade(f *framework.Framework) {
 		image            = "quay.io/interconnectedcloud/qdrouterd"
 		initialVersion   = "1.8.0"
 		finalVersion     = "1.9.0"
-		initialVersionLF = "1.8.0\n"
-		finalVersionLF   = "1.9.0\n"
 		size             = 3
 	)
 
@@ -51,7 +49,7 @@ func testInteriorImageUpgrade(f *framework.Framework) {
 	By("Waiting until full interconnect with size and initial version")
 	ctx1, fn := context.WithTimeout(context.Background(), framework.Timeout)
 	defer fn()
-	err = f.WaitUntilFullInterconnectWithVersion(ctx1, ei, size, initialVersionLF)
+	err = f.WaitUntilFullInterconnectWithVersion(ctx1, ei, size, initialVersion)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Waiting until full interconnect initial qdr entities")
@@ -72,7 +70,7 @@ func testInteriorImageUpgrade(f *framework.Framework) {
 	By("Waiting until full interconnect with size and final version")
 	ctx3, fn := context.WithTimeout(context.Background(), framework.Timeout)
 	defer fn()
-	err = f.WaitUntilFullInterconnectWithVersion(ctx3, ei, size, finalVersionLF)
+	err = f.WaitUntilFullInterconnectWithVersion(ctx3, ei, size, finalVersion)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Waiting until full interconnect with final qdr entities")


### PR DESCRIPTION
* Improved version matching mechanism to work upstream and downstream
* A few tweaks on timeouts for E2E tests to work properly against remote clusters