### PR TITLE
Added configuration validation for existing basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ metadata:
 spec:
   # Add fields here
   deploymentPlan:
-    image: quay.io/interconnectedcloud/qdrouterd:1.7.0
+    image: quay.io/interconnectedcloud/qdrouterd:1.9.0
     role: interior
     size: 3
     placement: Any
@@ -187,7 +187,7 @@ metadata:
   name: example-interconnect
 spec:
   deploymentPlan:
-    image: quay.io/interconnectedcloud/qdrouterd:1.7.0
+    image: quay.io/interconnectedcloud/qdrouterd:1.9.0
     role: interior
     size: 3
     placement: Any

--- a/test/e2e/framework/qdrmanagement/qdmanage.go
+++ b/test/e2e/framework/qdrmanagement/qdmanage.go
@@ -16,6 +16,8 @@ var (
 	queryCommand = []string{"qdmanage", "query", "--type"}
 )
 
+// QdmanageQuery executes a "qdmanager query" command on the provided pod, returning
+// a slice of entities of the provided "entity" type.
 func QdmanageQuery(f *framework.Framework, pod string, entity entities.Entity, fn func(entities.Entity) bool) ([]entities.Entity, error) {
 	// Preparing command to execute
 	command := append(queryCommand, entity.GetEntityId())

--- a/test/e2e/validation/address.go
+++ b/test/e2e/validation/address.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
+	"github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+)
+
+// ValidateDefaultAddresses verifies that the created addresses match expected ones
+func ValidateDefaultAddresses(ic *v1alpha1.Interconnect, f *framework.Framework, pods []v1.Pod) {
+
+	const expectedAddresses = 5
+
+	for _, pod := range pods {
+		var defaultAddressesFound = 0
+
+		// Querying addresses on given pod
+		addrs, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.Address{}, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(len(addrs)).To(gomega.Equal(expectedAddresses))
+
+		// Validates all addresses are present and match expected definition
+		for _, entity := range addrs {
+			addr := entity.(entities.Address)
+			switch addr.Prefix {
+			case "closest":
+				fallthrough
+			case "unicast":
+				fallthrough
+			case "exclusive":
+				ValidateEntityValues(addr, map[string]interface{}{
+					"Distribution": entities.DistributionClosest,
+				})
+				defaultAddressesFound++
+			case "multicast":
+				fallthrough
+			case "broadcast":
+				ValidateEntityValues(addr, map[string]interface{}{
+					"Distribution": entities.DistributionMulticast,
+				})
+				defaultAddressesFound++
+			}
+		}
+
+		// Assert default addresses have been found
+		gomega.Expect(expectedAddresses).To(gomega.Equal(defaultAddressesFound))
+	}
+
+}
+

--- a/test/e2e/validation/connector.go
+++ b/test/e2e/validation/connector.go
@@ -1,0 +1,61 @@
+package validation
+
+import (
+	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities/common"
+	"github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+)
+
+// ValidateDefaultConnectors asserts that the inter-router connectors are defined
+// in [deployment plan size - 1] routers (as the initial pod only provides listeners).
+// It returns number of connectors found.
+func ValidateDefaultConnectors(interconnect *v1alpha1.Interconnect, f *framework.Framework, pods []v1.Pod) {
+
+	totalConnectors := 0
+	expConnectors := 0
+
+	// Expected number of connectors defined by sum of all numbers from 1 to size - 1
+	for i := int(interconnect.Spec.DeploymentPlan.Size) - 1; i > 0; i-- {
+		expConnectors += i
+	}
+
+	// Iterate through pods
+	for _, pod := range pods {
+		// Retrieve connectors
+		connectors, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.Connector{}, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Common connector properties
+		expectedPort := "55672"
+		expectedSslProfile := ""
+		if f.CertManagerPresent {
+			expectedPort = "55671"
+			expectedSslProfile = "inter-router"
+		}
+
+		props := map[string]interface{}{
+			"Role":       common.RoleInterRouter,
+			"Port":       expectedPort,
+			"SslProfile": expectedSslProfile,
+		}
+
+		// Validate connectors
+		if len(connectors) > 0 {
+			for _, entity := range connectors {
+				connector := entity.(entities.Connector)
+				gomega.Expect(connector.Host).NotTo(gomega.BeEmpty())
+				ValidateEntityValues(connector, props)
+			}
+		}
+
+		totalConnectors += len(connectors)
+	}
+
+	// Validate number of connectors across pods
+	gomega.Expect(expConnectors).To(gomega.Equal(totalConnectors))
+
+}

--- a/test/e2e/validation/entity.go
+++ b/test/e2e/validation/entity.go
@@ -1,0 +1,20 @@
+package validation
+
+import (
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
+	"github.com/onsi/gomega"
+	"reflect"
+)
+
+// ValidateEntityValues uses reflect to compare values from a given entity's field
+// with the provided value from fieldValues map.
+//
+// This way you do not need to compare the whole entity, but just the fields that
+// are relevant to match.
+func ValidateEntityValues(entity entities.Entity, fieldValues map[string]interface{}) {
+	element := reflect.Indirect(reflect.ValueOf(entity))
+	for field, fieldValue := range fieldValues {
+		currentValue := element.FieldByName(field).Interface()
+		gomega.Expect(currentValue).To(gomega.Equal(fieldValue))
+	}
+}

--- a/test/e2e/validation/listener.go
+++ b/test/e2e/validation/listener.go
@@ -1,0 +1,111 @@
+package validation
+
+import (
+	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities/common"
+	"github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+)
+
+// ValidateDefaultListeners ensures that the default listeners (if no others specified)
+// have been created
+func ValidateDefaultListeners(ic *v1alpha1.Interconnect, f *framework.Framework, pods []v1.Pod) {
+	var expLs int = 3
+	var expIntLs int = 2
+
+	// Expected inter-router listener port might change if CertManager is present
+	var interRouterPort = "55672"
+	var interRouterSslProfile = ""
+	if f.CertManagerPresent {
+		expLs++
+		interRouterPort = "55671"
+		interRouterSslProfile = "inter-router"
+	}
+
+	for _, pod := range pods {
+		var lsFound int = 0
+		var intLsFound int = 0
+
+		listeners, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.Listener{}, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Validate returned listeners
+		for _, e := range listeners {
+			l := e.(entities.Listener)
+			switch l.Port {
+			case "5671":
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port": "5671",
+					"Role": common.RoleNormal,
+					"Http": false,
+				})
+				lsFound++
+			case "5672":
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port": "5672",
+					"Role": common.RoleNormal,
+					"Http": false,
+				})
+				lsFound++
+			case "8080":
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port":             "8080",
+					"Role":             common.RoleNormal,
+					"Http":             true,
+					"AuthenticatePeer": true,
+				})
+				lsFound++
+			case "8888":
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port":        "8888",
+					"Role":        common.RoleNormal,
+					"Http":        true,
+					"Healthz":     true,
+					"Metrics":     true,
+					"Websockets":  false,
+					"HttpRootDir": "invalid",
+				})
+				lsFound++
+			}
+		}
+
+		// Expect default listener count to match
+		gomega.Expect(expLs).To(gomega.Equal(lsFound))
+
+		//
+		// Interior only
+		//
+		if ic.Spec.DeploymentPlan.Role != v1alpha1.RouterRoleInterior {
+			return
+		}
+
+		// Validate interior listeners
+		for _, e := range listeners {
+			l := e.(entities.Listener)
+			switch l.Port {
+			// inter-router listener
+			case interRouterPort:
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port":       interRouterPort,
+					"Role":       common.RoleInterRouter,
+					"SslProfile": interRouterSslProfile,
+				})
+				intLsFound++
+			// edge listener
+			case "45672":
+				ValidateEntityValues(l, map[string]interface{}{
+					"Port": "45672",
+					"Role": common.RoleEdge,
+				})
+				intLsFound++
+			}
+		}
+
+		// Validate all default interior listeners are present
+		gomega.Expect(expIntLs).To(gomega.Equal(intLsFound))
+	}
+}
+

--- a/test/e2e/validation/sslprofile.go
+++ b/test/e2e/validation/sslprofile.go
@@ -1,0 +1,55 @@
+package validation
+
+import (
+	"fmt"
+	"github.com/interconnectedcloud/qdr-operator/pkg/apis/interconnectedcloud/v1alpha1"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement"
+	"github.com/interconnectedcloud/qdr-operator/test/e2e/framework/qdrmanagement/entities"
+	"github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+)
+
+// ValidateDefaultSslProfiles asserts that the default sslProfile entities have
+// been defined, based on given Interconnect's role.
+func ValidateDefaultSslProfiles(ic *v1alpha1.Interconnect, f *framework.Framework, pods []v1.Pod) {
+
+	var expectedSslProfiles = 1
+	var isInterior = ic.Spec.DeploymentPlan.Role == v1alpha1.RouterRoleInterior
+
+	// Interior routers have an extra sslProfile for the inter-router listener
+	if isInterior {
+		expectedSslProfiles++
+	}
+
+	// Iterate through the pods to ensure sslProfiles are defined
+	for _, pod := range pods {
+		var sslProfilesFound = 0
+
+		// Retrieving sslProfile entities from router
+		sslProfiles, err := qdrmanagement.QdmanageQuery(f, pod.Name, entities.SslProfile{}, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify expected sslProfiles are defined
+		for _, entity := range sslProfiles {
+			sslProfile := entity.(entities.SslProfile)
+			switch sslProfile.Name {
+			case "inter-router":
+				ValidateEntityValues(sslProfile, map[string]interface{}{
+					"CaCertFile": fmt.Sprintf("/etc/qpid-dispatch-certs/%s/%s-%s-credentials/ca.crt", sslProfile.Name, ic.Name, sslProfile.Name),
+				})
+				fallthrough
+			case "default":
+				ValidateEntityValues(sslProfile, map[string]interface{}{
+					"CertFile":       fmt.Sprintf("/etc/qpid-dispatch-certs/%s/%s-%s-credentials/tls.crt", sslProfile.Name, ic.Name, sslProfile.Name),
+					"PrivateKeyFile": fmt.Sprintf("/etc/qpid-dispatch-certs/%s/%s-%s-credentials/tls.key", sslProfile.Name, ic.Name, sslProfile.Name),
+				})
+				sslProfilesFound++
+			}
+		}
+
+		// Assert default sslProfiles have been found
+		gomega.Expect(expectedSslProfiles).To(gomega.Equal(sslProfilesFound))
+	}
+
+}


### PR DESCRIPTION
* Modified basic tests to validate configuration of entities
* Remove validation of listeners from pods logs
* Minor improvement to framework to keep CRD if defined previously
* Created validation package to store common validation methods