### PR TITLE
Update Travis.CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 before_install:
   # Install Go Dep
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-  - dep ensure
+  - dep ensure --vendor-only
 
   # Get tools
   - go get sigs.k8s.io/kind

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 language: go
 go:
   - master
+  - 1.14.x
   - 1.13.x
 
 cache:
@@ -55,6 +56,8 @@ before_install:
   # Setup
   - cd $GOPATH/src/github.com/interconnectedcloud/qdr-operator
   - dep ensure -v && dep status
+
+  # Install 
 
 script:
   - cd $GOPATH/src/github.com/interconnectedcloud/qdr-operator

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ go:
   - master
   - 1.13.x
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
+
 go_import_path: github.com/interconnectedcloud/qdr-operator
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 language: go
 go:
   - master
-  - 1.12.x
+  - 1.13.x
 
 go_import_path: github.com/interconnectedcloud/qdr-operator
 
@@ -17,7 +17,7 @@ env:
   global:
     - KUBECONFIG=$HOME/.kube/config
     - KUBERNETES_VERSION=$(curl -k -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-    - OPERATORSDK_VERSION=v0.12.0
+    - OPERATORSDK_VERSION=v0.17.0
 
     # QDR
     - REGISTRY=quay.io/interconnectedcloud


### PR DESCRIPTION
- Added build cache to Travis.CI
- Updated Go to 1.14.x, 1.13.x, and 1.12.x was removed
- Updated Operator SDK to 17.0

Travis results: [enkeys:travis-update](https://travis-ci.com/github/enkeys/qdr-operator/builds/160533522)