### PR TITLE
Add `name: ""` to CSV resources list

### DIFF
--- a/deploy/olm-catalog/qdr-operator/0.4.0/qdr-operator.v0.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/qdr-operator/0.4.0/qdr-operator.v0.4.0.clusterserviceversion.yaml
@@ -19,24 +19,34 @@ spec:
       name: interconnects.interconnectedcloud.github.io
       resources:
       - kind: Service
+        name: ""
         version: v1
       - kind: Deployment
+        name: ""
         version: v1
       - kind: ServiceAccount
+        name: ""
         version: v1
       - kind: interconnects
+        name: ""
         version: v1alpha1
       - kind: rolebindings
+        name: ""
         version: v1
       - kind: pods
+        name: ""
         version: v1
       - kind: configmaps
+        name: ""
         version: v1
       - kind: roles
+        name: ""
         version: v1
       - kind: routes
+        name: ""
         version: v1
       - kind: secrets
+        name: ""
         version: v1
       specDescriptors:
       - description: The role and placement plan for the interconnect deployment


### PR DESCRIPTION
Add the `name: ""` parameter to the CSV `resources` list so that it passes validation.

Without this change when importing to a modern Kubernetes, you get this error:

```
error: error validating "STDIN": error validating data: [ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[0]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[1]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[2]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[3]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[4]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[5]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[6]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[7]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[8]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources, ValidationError(ClusterServiceVersion.spec.customresourcedefinitions.owned[0].resources[9]): missing required field "name" in com.coreos.operators.v1alpha1.ClusterServiceVersion.spec.customresourcedefinitions.owned.resources]; if you choose to ignore these errors, turn validation off with --validate=false
```